### PR TITLE
Fix an issue due to shallow config merging with Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "request": "^2.72.0",
     "request-promise": "^4.1.0",
     "twilio": "^2.11.1",
+    "webpack-merge": "^4.1.0",
     "winston": "^2.3.0",
     "yamljs": "^0.2.8"
   },

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,12 +1,14 @@
 import Yaml from 'yamljs';
 import Promise from 'bluebird';
+import merge from 'webpack-merge';
 import defaultConfig from './default.config';
 
 global.Promise = Promise;
 
 // TODO: Need a way to specify config file from CLI option.
+// TODO: Currently the config merging stuff is not testable, need to make it testable.
 const CONFIG_FILE_NAME = (process.env.NODE_ENV === 'test') ? 'chill.test.yml' : 'chill.yml';
 const loadedConfig = Yaml.load(CONFIG_FILE_NAME);
-const config = Object.assign({}, defaultConfig, loadedConfig);
+const config = merge(defaultConfig, loadedConfig);
 
 export default config;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import 'babel-polyfill';
+import merge from 'webpack-merge';
 import config from './config/config';
 import Monitor from './monitoring/Monitor';
 import * as eventListener from './monitoring/eventListener';
@@ -6,7 +7,7 @@ import * as eventListener from './monitoring/eventListener';
 eventListener.listen();
 
 config.services.forEach(service => {
-  let serviceConfig = Object.assign({}, config.monitoring, service);
+  let serviceConfig = merge(config.monitoring, service);
   let monitor = new Monitor(serviceConfig);
 
   monitor.start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,7 +2112,7 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2849,10 +2849,6 @@ restore-cursor@^1.0.1:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
 
-rewire@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/rewire/-/rewire-2.5.2.tgz#6427de7b7feefa7d36401507eb64a5385bc58dc7"
-
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -3308,6 +3304,12 @@ verror@1.3.6:
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
+
+webpack-merge@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.0.tgz#6ad72223b3e0b837e531e4597c199f909361511e"
+  dependencies:
+    lodash "^4.17.4"
 
 which@^1.1.1, which@^1.2.9:
   version "1.2.14"


### PR DESCRIPTION
We seem to have an issue due to shallow config merging with `Object.assign()`. 

The error shows up when you don't have twilio configurations in your local `chill.yml` file. 
```
/home/kabir/opensource/chill/src/utils/twilioClient.js:17
var AUTH_TOKEN = _config2.default.notifications.twilio.authToken;
                                                      ^

TypeError: Cannot read property 'authToken' of undefined
    at Object.<anonymous> (/home/kabir/opensource/chill/src/utils/twilioClient.js:4:20)
    at Module._compile (module.js:571:32)
    at loader (/home/kabir/opensource/chill/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/home/kabir/opensource/chill/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/kabir/opensource/chill/src/services/twilio.js:4:1)
    at Module._compile (module.js:571:32)
    at loader (/home/kabir/opensource/chill/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/home/kabir/opensource/chill/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/kabir/opensource/chill/src/services/notifier.js:2:1)
    at Module._compile (module.js:571:32)
    at loader (/home/kabir/opensource/chill/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/home/kabir/opensource/chill/node_modules/babel-register/lib/node.js:154:7)
[nodemon] app crashed - waiting for file changes before starting...
```
Also, we do need recursive config merging here as we have nested config structure. 

@leapfrogtechnology/the-chill-team if you guys has any other lightweight solution for deep merging over webpack-merge we can use that too. 
