### PR TITLE
Fix CLI tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets": ["es2015", "es2016", "es2017"]
+    "presets": ["es2015", "es2016", "es2017"],
+    "plugins": ["dynamic-import-node"]
 }

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,7 +8,7 @@ parserOptions:
   sourceType: module
 
 extends: 'eslint:recommended'
-
+parser: babel-eslint
 rules:
   no-var: 2
   key-spacing: 2

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "babel-eslint": "^7.2.3",
     "babel-plugin-dynamic-import-node": "^1.0.2",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-es2016": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
+    "babel-plugin-dynamic-import-node": "^1.0.2",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-es2016": "^6.24.1",
     "babel-preset-es2017": "^6.24.1",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,8 +1,6 @@
 import 'babel-polyfill';
 import yargs from 'yargs';
 import chill from '../../package';
-import init from '../monitoring/init';
-import * as config from '../config/config';
 
 const name = 'chill';
 
@@ -24,4 +22,9 @@ yargs.options({
 let argv = yargs.argv;
 
 // Initialize the application with the provided config.
-init(config.resolve(argv.config));
+(async () => {
+  const config = await import('../config/config');
+  const init = await import('../monitoring/init');
+
+  init(config.resolve(argv.config);
+})();

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,12 +1,14 @@
 import 'babel-polyfill';
 import yargs from 'yargs';
 import chill from '../../package';
+import init from '../monitoring/init';
 
-const name = 'chill';
+const APP_NAME = 'chill';
+const APP_NAME_VERSION_STRING = `${APP_NAME} ${chill.version}`;
 
 yargs
-  .usage(`Usage: ${name} [options]`, { 'a': {} })
-  .version('version', `${name} ${chill.version}`)
+  .usage(`Usage: ${APP_NAME} [options]`, { 'a': {} })
+  .version('version', APP_NAME_VERSION_STRING)
   .alias('V', 'version')
   .help('h')
   .alias('h', 'help');
@@ -14,17 +16,11 @@ yargs
 yargs.options({
   'c': {
     alias: 'config',
-    default: 'chill.yml',
     describe: 'Configuration file path.'
   }
 });
 
-let argv = yargs.argv;
+const argv = yargs.argv;
 
-// Initialize the application with the provided config.
-(async () => {
-  const config = await import('../config/config');
-  const init = await import('../monitoring/init');
-
-  init(config.resolve(argv.config));
-})();
+// Initialize the application with the provided configuration.
+init(argv.config);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -26,5 +26,5 @@ let argv = yargs.argv;
   const config = await import('../config/config');
   const init = await import('../monitoring/init');
 
-  init(config.resolve(argv.config);
+  init(config.resolve(argv.config));
 })();

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -17,6 +17,8 @@ export const DEFAULT_FILENAME = 'chill.yml';
  * @returns {Object}
  */
 export function resolve(filename = DEFAULT_FILENAME) {
+  process.stdout.write(`Loading config file: ${filename}\n`);
+
   let loadedConfig = Yaml.load(filename);
   let config = merge(defaultConfig, loadedConfig);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import 'babel-polyfill';
 import init from './monitoring/init';
-import * as config from './config/config';
 
 // Initialize the application with the local configuration.
-init(config.resolve());
+init();

--- a/src/monitoring/init.js
+++ b/src/monitoring/init.js
@@ -10,7 +10,8 @@ export default async function init(configFile) {
   try {
     const { resolve } = await import ('../config/config');
 
-    configFile = configFile || path.resolve('chill.yml');
+    // Config file for chill could be added using environment variables too.
+    configFile = configFile || process.env.CHILL_CONFIG || path.resolve('chill.yml');
 
     const config = resolve(configFile);
     const { 'default': Monitor } = await import('./Monitor');

--- a/src/monitoring/init.js
+++ b/src/monitoring/init.js
@@ -1,11 +1,24 @@
-import Monitor from './Monitor';
-import * as eventListener from './eventListener';
+import path from 'path';
+import chill from '../../package';
 
 /**
  * Initialize the monitor and start monitoring configured services.
  */
-export default function init(config) {
-  eventListener.listen();
+export default async function init(configFile) {
+  process.stdout.write(`Starting chill ${chill.version}\n`);
 
-  config.services.forEach(service => (new Monitor(service)).start());
+  try {
+    const { resolve } = await import ('../config/config');
+
+    configFile = configFile || path.resolve('chill.yml');
+
+    const config = resolve(configFile);
+    const { 'default': Monitor } = await import('./Monitor');
+    const eventListener = await import('./eventListener');
+
+    eventListener.listen();
+    config.services.forEach(service => (new Monitor(service)).start());
+  } catch (err) {
+    process.stderr.write('An error occurred: \n' + err);
+  }
 }

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -3,18 +3,21 @@ import { assert } from 'chai';
 import pkg from '../../package.json';
 
 describe('cli', () => {
+  shell.fatal = true;
+
   describe('--version', () => {
     it('should print the chill cli version', () => {
-      let result = shell.exec('bin/chill --version', { silent: true }).stdout.trim();
+      let { stdout } = shell.exec('bin/chill --version', { fatal: true });
       let expected = `chill ${pkg.version}`;
 
-      assert.equal(result, expected);
+      assert.equal(stdout.trim(), expected);
     });
   });
 
   describe('--help', () => {
     it('should print the chill usage help string', () => {
-      let result = shell.exec('bin/chill --help', { silent: true }).stdout.trim();
+      let { stdout } = shell.exec('bin/chill --help', { fatal: true });
+      let result = stdout.trim();
 
       assert.include(result, 'Usage: chill');
       assert.include(result, 'Options:');

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,9 +354,21 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dynamic-import-node@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.0.2.tgz#adb5bc8f48a89311540395ae9f0cc3ed4b10bb2e"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,6 +228,15 @@ babel-core@^6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
+babel-eslint@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.17.0"
+
 babel-generator@^6.18.0, babel-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
@@ -654,7 +663,7 @@ babel-template@^6.16.0, babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1:
+babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -668,7 +677,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
@@ -677,7 +686,7 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
+babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.17.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
 


### PR DESCRIPTION
CLI tests were failing if `chill.yml` is not found since the config were being imported before the code could even run. So, I used the [ES dynamic `import`](https://github.com/tc39/proposal-dynamic-import) to solve this.

Also, we can now specify config file using environment variable `CHILL_CONFIG`. We can use this env variable to share `chill.yml` config file across rest-api, dashboard and the chill cli/monitor