### PR TITLE
Configure maxFiles option for logging for auto log files removal

### DIFF
--- a/src/config/default.config.js
+++ b/src/config/default.config.js
@@ -2,12 +2,13 @@ import path from 'path';
 
 export default {
   logging: {
+    maxFiles: 3,
     level: 'info',
     logDir: 'logs',
     jsonFormat: false,
     levelColumnWidth: 7,
-    tsFormat: () => new Date().toISOString(),
-    dateFormat: 'yyyy-MM-dd'
+    dateFormat: 'yyyy-MM-dd',
+    tsFormat: () => new Date().toISOString()
   },
   db: {
     client: 'sqlite3',

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -56,6 +56,7 @@ function createLogger(config) {
   const {
     level,
     logDir,
+    maxFiles,
     tsFormat,
     jsonFormat,
     dateFormat
@@ -67,16 +68,18 @@ function createLogger(config) {
     transports: [
       new winston.transports.Console({
         level: level,
-        colorize: true, 
+        colorize: true,
         timestamp: tsFormat,
         formatter: opts => customFormatter(opts, config)
       }),
       new winston.transports.DailyRotateFile({
+        maxFiles,
         align: true,
         level: level,
         prepend: true,
         json: jsonFormat,
         timestamp: tsFormat,
+        zippedArchive: true,
         datePattern: dateFormat,
         filename: `${logDir}/-log.log`,
         formatter: opts => customFormatter(opts, config)


### PR DESCRIPTION
Old log files were not being removed right now. This will only keep limited log files (as per specified in maxFiles option).