### PR TITLE
Fix color and messaging format for Slack

### DIFF
--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -2,7 +2,6 @@ import { STATUS_UP, STATUS_DOWN } from '../services/status';
 
 const messages = {
   [STATUS_UP]: {
-    color: 'green',
     title: 'Service is Up',
     text: (name, downtime) => {
       return `${name} is up` + (downtime ? ` after ${downtime} of downtime.` : '.');
@@ -10,7 +9,6 @@ const messages = {
   },
 
   [STATUS_DOWN]: {
-    color: 'red',
     title: 'Service is Down',
     text: (name) => `${name} went down.`
   }

--- a/src/config/default.config.js
+++ b/src/config/default.config.js
@@ -25,21 +25,21 @@ export default {
   },
   notifications: {
     slack: {
+      enabled: false,
       color: {
         up: 'good',
         down: 'danger'
       },
-      enabled: false,
       endpoint: null,
       baseUrl: 'https://hooks.slack.com/services'
     },
     hipchat: {
+      enabled: false,
+      notify: true,
       color: {
         up: 'green',
         down: 'red'
       },
-      notify: true,
-      enabled: false,
       roomId: null,
       authToken: null,
       emailId: 'chill@noreply.com',

--- a/src/config/default.config.js
+++ b/src/config/default.config.js
@@ -25,11 +25,19 @@ export default {
   },
   notifications: {
     slack: {
+      color: {
+        up: 'good',
+        down: 'danger'
+      },
       enabled: false,
       endpoint: null,
       baseUrl: 'https://hooks.slack.com/services'
     },
     hipchat: {
+      color: {
+        up: 'green',
+        down: 'red'
+      },
       notify: true,
       enabled: false,
       roomId: null,

--- a/src/services/hipchat.js
+++ b/src/services/hipchat.js
@@ -42,12 +42,12 @@ export async function notify(params) {
  */
 function preparePayload(params) {
   let { status, name } = params;
-  let { text, color } = messages[status];
-  let { email, notify } = config.get().notifications.hipchat;
+  let { text } = messages[status];
+  let { email, color, notify } = config.get().notifications.hipchat;
 
   return {
     message: text(name, params.downtime),
-    color: color,
+    color: color[status],
     from: email,
     value: name,
     notify: notify

--- a/src/services/slack.js
+++ b/src/services/slack.js
@@ -42,20 +42,14 @@ export async function notify(params) {
  */
 function preparePayload(params) {
   const { status, name } = params;
-  const { text, color } = messages[status];
+  const { text } = messages[status];
+  const { color } = config.get().notifications.slack;
 
   return {
-    text: text(name, params.downtime),
     attachments: [
       {
-        color: color,
-        fields: [
-          {
-            short: true,
-            value: name,
-            title: 'Service'
-          }
-        ]
+        color: color[status],
+        text: text(name, params.downtime)
       }
     ]
   };

--- a/test/services/hipchat.test.js
+++ b/test/services/hipchat.test.js
@@ -23,6 +23,10 @@ describe('hipchat.isEnabled', () => {
       notifications: {
         hipchat: {
           enabled: true,
+          color: {
+            up: faker.random.word(),
+            down: faker.random.word()
+          },
           roomId: faker.random.word(),
           authToken: faker.random.word()
         }
@@ -56,6 +60,10 @@ describe('hipchat.notify', () => {
       notifications: {
         hipchat: {
           enabled: true,
+          color: {
+            up: faker.random.word(),
+            down: faker.random.word()
+          },
           roomId,
           authToken
         }

--- a/test/services/slack.test.js
+++ b/test/services/slack.test.js
@@ -22,6 +22,10 @@ describe('slack.isEnabled', () => {
     sandbox.stub(config, 'get').returns({
       notifications: {
         slack: {
+          color: {
+            up: faker.random.word(),
+            down: faker.random.word()
+          },
           enabled: true,
           endpoint: faker.random.word()
         }
@@ -54,6 +58,10 @@ describe('slack.notify', () => {
       notifications: {
         slack: {
           enabled: true,
+          color: {
+            up: faker.random.word(),
+            down: faker.random.word()
+          },
           endpoint: slackEndpoint
         }
       }

--- a/test/services/slack.test.js
+++ b/test/services/slack.test.js
@@ -50,6 +50,7 @@ describe('slack.isEnabled', () => {
 
 describe('slack.notify', () => {
   let sandbox;
+  let baseUrl = faker.internet.url() + '/';
   let slackEndpoint = faker.lorem.slug();
 
   beforeEach(() => {
@@ -62,7 +63,8 @@ describe('slack.notify', () => {
             up: faker.random.word(),
             down: faker.random.word()
           },
-          endpoint: slackEndpoint
+          endpoint: slackEndpoint,
+          baseUrl
         }
       }
     });
@@ -74,7 +76,7 @@ describe('slack.notify', () => {
 
   it('should send the notification payload to the slack API endpoint.', () => {
     let rpStub = sandbox.stub(rp, 'post').callsFake(params => {
-      assert.match(params.url, new RegExp(`^https://.*${slackEndpoint}$`));
+      assert.equal(params.url, `${baseUrl}${slackEndpoint}`);
       assert.isObject(params.body);
 
       return Promise.resolve();

--- a/test/services/twilio.test.js
+++ b/test/services/twilio.test.js
@@ -64,7 +64,23 @@ describe('twilio.notify', () => {
   });
 
   it('should send notification from twilio with correct params', () => {
-    let sendMessageStub = sandbox.stub();
+    let sendMessageStub = sandbox.stub().returns({
+      // Fake response from https://www.twilio.com/docs/api/rest/response
+      'sid': 'SM1f0e8ae6ade43cb3c0ce4525424e404f',
+      'date_created': 'Fri, 13 Aug 2010 01:16:24 +0000',
+      'date_updated': 'Fri, 13 Aug 2010 01:16:24 +0000',
+      'date_sent': null,
+      'account_sid': 'AC228b97a5fe4138be081eaff3c44180f3',
+      'to': '+15305431221',
+      'from': '+15104564545',
+      'body': 'A Test Message',
+      'status': 'queued',
+      'flags': [ 'outbound' ],
+      'api_version': '2010-04-01',
+      'price': null,
+      'uri': '\/2010-04-01\/Accounts\/AC228ba7a5fe4238be081ea6f3c44186f3\/SMS\/Messages\/SM1f0e8ae6ade43cb3c0ce4525424e404f.json'
+    });
+
     let twilioSerivce = proxyquire('../../src/services/twilio', {
       twilio() {
         return { sendMessage: sendMessageStub };


### PR DESCRIPTION
Slack and Hipchat both use different color codes for formatting their message.

* Remove color from common messages
* Add color to default config for slack and hipchat

Note: I've not had the chance to test this. Someone should do it.