### PR TITLE
Create https util to get SSL info for given host

### DIFF
--- a/monitor/src/utils/https.js
+++ b/monitor/src/utils/https.js
@@ -1,0 +1,40 @@
+import https from 'https';
+
+import { OPTIONS } from './http';
+
+export const DEFAULT_SSL_PORT = 443;
+
+/**
+ * Get details about SSL certificate for given host.
+ *
+ * @param {string} host
+ * @param {string} method
+ * @param {number} port
+ */
+export function getSSLInfo(host, port = DEFAULT_SSL_PORT, method = OPTIONS) {
+  const options = {
+    host,
+    port,
+    method,
+    agent: false,
+    rejectUnauthorized: false,
+  };
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, res => {
+      const { valid_from: validFrom, valid_to: validTo } = res.connection.getPeerCertificate();
+
+      resolve({
+        validTo,
+        validFrom,
+        valid: res.socket.authorized,
+      });
+    });
+
+    req.on('error', e => {
+      reject(e);
+    });
+
+    req.end();
+  });
+}

--- a/monitor/src/utils/https.js
+++ b/monitor/src/utils/https.js
@@ -31,9 +31,7 @@ export function getSSLInfo(host, port = DEFAULT_SSL_PORT, method = OPTIONS) {
       });
     });
 
-    req.on('error', e => {
-      reject(e);
-    });
+    req.on('error', e => reject(e));
 
     req.end();
   });


### PR DESCRIPTION
## Changes

* Create https util to get SSL info for given host

## Details

This util uses the `res.connection.getPeerCertificate()` method to get details about the SSL certificate and then returns object as shown in following example:

```js
{
  validFrom: "Jul 25 00:00:00 2018 GMT",
  validTo: "Oct 23 23:59:59 2019 GMT",
  valid: true
}
```